### PR TITLE
Update tasks when task configuration options change

### DIFF
--- a/lib/elastic_whenever/option.rb
+++ b/lib/elastic_whenever/option.rb
@@ -159,6 +159,25 @@ module ElasticWhenever
       raise InvalidOptionException.new("Invalid rule state. Possible values are #{POSSIBLE_RULE_STATES.join(", ")}") unless POSSIBLE_RULE_STATES.include?(rule_state)
     end
 
+    def key
+      Digest::SHA1.hexdigest(
+        [
+          identifier,
+          variables,
+          cluster,
+          task_definition,
+          container,
+          assign_public_ip,
+          launch_type,
+          platform_version,
+          security_groups,
+          subnets,
+          iam_role,
+          rule_state,
+        ].join
+      )
+    end
+
     private
 
     attr_reader :profile

--- a/lib/elastic_whenever/task/rule.rb
+++ b/lib/elastic_whenever/task/rule.rb
@@ -25,7 +25,7 @@ module ElasticWhenever
       def self.convert(option, expression, command)
         self.new(
           option,
-          name: rule_name(option.identifier, expression, command),
+          name: rule_name(option, expression, command),
           expression: expression,
           description: rule_description(option.identifier, expression, command)
         )
@@ -65,8 +65,8 @@ module ElasticWhenever
 
       private
 
-      def self.rule_name(identifier, expression, command)
-        "#{identifier}_#{Digest::SHA1.hexdigest([expression, command.join("-")].join("-"))}"
+      def self.rule_name(option, expression, command)
+        "#{option.identifier}_#{Digest::SHA1.hexdigest([option.key, expression, command.join("-")].join("-"))}"
       end
 
       def self.rule_description(identifier, expression, command)

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ElasticWhenever::CLI do
     let(:cluster) { double(arn: "arn:aws:ecs:us-east-1:123456789:cluster/test", name: "test") }
     let(:definition) { double(arn: "arn:aws:ecs:us-east-1:123456789:task-definition/wordpress:2", name: "wordpress:2", containers: ["testContainer"]) }
     let(:role) { double(arn: "arn:aws:ecs:us-east-1:123456789:role/testRole") }
-    let(:rule) { double(name: "test_9c958bdba560ec9808317b1f8627c242ed36e6a6", description: "test - cron(0 0 * * ? *) - bundle exec bin/rails runner -e production Hoge.run") }
+    let(:rule) { double(name: "test_2f41f32af2d2a46d5c024f12448894066ae90036", description: "test - cron(0 0 * * ? *) - bundle exec bin/rails runner -e production Hoge.run") }
     before do
       allow(ElasticWhenever::Schedule).to receive(:new).with((Pathname(__dir__) + "fixtures/schedule.rb").to_s, boolean, kind_of(Array)).and_return(schedule)
       allow(ElasticWhenever::Task::Cluster).to receive(:new).with(kind_of(ElasticWhenever::Option), "test").and_return(cluster)

--- a/spec/tasks/rule_spec.rb
+++ b/spec/tasks/rule_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ElasticWhenever::Task::Rule do
       task.rake "command:foo"
 
       expect(ElasticWhenever::Task::Rule.convert(option, task.expression, task.commands.first)).to have_attributes(
-                                                                     name: "test_9bd25c94ceb04edcaa64946e7ed84f13644d655f",
+                                                                     name: "test_6a6abf21a362cde702bd39f4679704598fad7ead",
                                                                      expression: "cron(0 0 * * ? *)",
                                                                      description: "test - cron(0 0 * * ? *) - bundle exec rake hoge:run --silent"
                                                                    )


### PR DESCRIPTION
When important configuration about a task updates, e.g., the task_definition revision or iam role etc. change, then the tasks should be updated.  This change adds a key to the options class which is then used in the rule name as a cache buster.