### PR TITLE
Set task defintion revision to latest if family is specified

### DIFF
--- a/lib/elastic_whenever/task/definition.rb
+++ b/lib/elastic_whenever/task/definition.rb
@@ -3,6 +3,7 @@ module ElasticWhenever
     class Definition
       def initialize(option, family)
         @client = option.ecs_client
+        @family = family
         @definition = client.describe_task_definition(
           task_definition: family
         ).task_definition
@@ -13,7 +14,12 @@ module ElasticWhenever
       end
 
       def arn
-        definition&.task_definition_arn
+        arn = definition&.task_definition_arn
+        if family_with_revision?
+          arn
+        else
+          remove_revision(arn)
+        end
       end
 
       def containers
@@ -24,6 +30,14 @@ module ElasticWhenever
 
       attr_reader :client
       attr_reader :definition
+
+      def family_with_revision?
+        @family.include?(":")
+      end
+
+      def remove_revision(arn)
+        arn.split(":")[0...-1].join(":")
+      end
     end
   end
 end

--- a/spec/tasks/definition_spec.rb
+++ b/spec/tasks/definition_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ElasticWhenever::Task::Definition do
   describe "definition attributes" do
     let(:client) { double("client") }
     let(:option) { ElasticWhenever::Option.new(nil) }
+    let(:family) { "wordpress" }
     let(:definition) do
       double(
         task_definition_arn: "arn:aws:ecs:us-east-1:1234567890:task_definition/wordpress:1",
@@ -15,15 +16,35 @@ RSpec.describe ElasticWhenever::Task::Definition do
 
     before do
       allow(Aws::ECS::Client).to receive(:new).and_return(client)
-      allow(client).to receive(:describe_task_definition).with(task_definition: "wordpress").and_return(double(task_definition: definition))
+      allow(client).to receive(:describe_task_definition).with(task_definition: family).and_return(double(task_definition: definition))
     end
 
     it "has task definition" do
-      expect(ElasticWhenever::Task::Definition.new(option, "wordpress")).to have_attributes(
+      expect(ElasticWhenever::Task::Definition.new(option, family)).to have_attributes(
                                                                               name: "wordpress:1",
-                                                                              arn: "arn:aws:ecs:us-east-1:1234567890:task_definition/wordpress:1",
+                                                                              arn: "arn:aws:ecs:us-east-1:1234567890:task_definition/wordpress",
                                                                               containers: ["testContainer"]
                                                                             )
+    end
+
+    context "with revision specified" do
+      let(:family) { "wordpress:2" }
+      let(:definition) do
+        double(
+          task_definition_arn: "arn:aws:ecs:us-east-1:1234567890:task_definition/wordpress:2",
+          family: "wordpress",
+          revision: 2,
+          container_definitions: [double(name: "testContainer")]
+        )
+      end
+
+      it "has task definition" do
+        expect(ElasticWhenever::Task::Definition.new(option, family)).to have_attributes(
+                                                                                name: "wordpress:2",
+                                                                                arn: "arn:aws:ecs:us-east-1:1234567890:task_definition/wordpress:2",
+                                                                                containers: ["testContainer"]
+                                                                              )
+      end
     end
   end
 end


### PR DESCRIPTION
This changes the behaviour of what task definition is selected when not specifying the revision. Previously this would select the current active one and set it to that, e.g. revision 5. If a new revision was released, due to a configuration change, e.g. revision 6, the old targets would be "stuck" on revision 5 which is now inactive and won't trigger any further tasks. This PR changes this to always use the latest revision.