### PR TITLE
Remove verbose logging, update README and add missing tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,13 @@ end
 Especially, `@environment` defaults to `"production"`.
 
 ## How it works
-Elastic Whenever creates CloudWatch Events as many as `every` block. Each event has as many targets as there are commands in the block.
+Elastic Whenever creates CloudWatch Events for every command. Each rule has a one to one mapping to a target.
+for example, the following input will generate two Rules each with one Target.
 
 ```ruby
-every '0 0 * * *' do # scheduled task (identifier_68237a3b152a6c44359e1cf5cd8e7cf0def303d7)
-  rake "hoge:run"    # target for `identifier_68237a3b152a6c44359e1cf5cd8e7cf0def303d7`
-  command "awesome"  # target for `identifier_68237a3b152a6c44359e1cf5cd8e7cf0def303d7`
+every '0 0 * * *' do
+  rake "hoge:run"
+  command "awesome"
 end
 ```
 

--- a/lib/elastic_whenever/cli.rb
+++ b/lib/elastic_whenever/cli.rb
@@ -41,7 +41,7 @@ module ElasticWhenever
       Logger.instance.fail("missing region error occurred; please use `--region` option or export `AWS_REGION` environment variable.")
       ERROR_EXIT_CODE
     rescue Aws::Errors::MissingCredentialsError => e
-      Logger.instance.fail("missing credential error occurred; please specify it with arguments, use shared credentials, or export `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variable. #{e.backtrace}")
+      Logger.instance.fail("missing credential error occurred; please specify it with arguments, use shared credentials, or export `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variable")
       ERROR_EXIT_CODE
     rescue OptionParser::MissingArgument,
       Option::InvalidOptionException,

--- a/lib/elastic_whenever/task/rule.rb
+++ b/lib/elastic_whenever/task/rule.rb
@@ -12,7 +12,6 @@ module ElasticWhenever
         client = option.cloudwatch_events_client
         prefix = option.identifier
 
-        Logger.instance.message("Fetching Rules for prefix: #{prefix} next_token: #{next_token}")
         response = client.list_rules(name_prefix: prefix, next_token: next_token)
         response.rules.each do |rule|
           rules << self.new(
@@ -63,9 +62,7 @@ module ElasticWhenever
       end
 
       def delete
-        Logger.instance.message("Listing Targets by Rule: #{name}")
         targets = client.list_targets_by_rule(rule: name).targets
-        Logger.instance.message("Removing Targets") unless targets.empty?
         client.remove_targets(rule: name, ids: targets.map(&:id)) unless targets.empty?
         Logger.instance.message("Removing Rule: #{name}")
         client.delete_rule(name: name)

--- a/lib/elastic_whenever/task/target.rb
+++ b/lib/elastic_whenever/task/target.rb
@@ -16,7 +16,6 @@ module ElasticWhenever
 
       def self.fetch(option, rule)
         client = option.cloudwatch_events_client
-        Logger.instance.message("Fetching Targets for: #{rule.name}")
         targets = client.list_targets_by_rule(rule: rule.name).targets
         targets.map do |target|
           input = JSON.parse(target.input, symbolize_names: true)
@@ -53,7 +52,6 @@ module ElasticWhenever
       end
 
       def create
-        Logger.instance.message("Creating Target: #{rule.name}")
         client.put_targets(
           rule: rule.name,
           targets: [

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -91,6 +91,19 @@ RSpec.describe ElasticWhenever::CLI do
         ElasticWhenever::CLI.new(args.concat(%W(--set environment=staging&foo=bar))).run
       end
 
+      it "creates the role if it doesn't exist" do
+        expect(role).to receive(:create)
+
+        expect(ElasticWhenever::CLI.new(args).run).to eq ElasticWhenever::CLI::SUCCESS_EXIT_CODE
+      end
+
+      it "does not create the role if it exists" do
+        allow(role).to receive(:exists?).and_return(true)
+        expect(role).not_to receive(:create)
+
+        expect(ElasticWhenever::CLI.new(args).run).to eq ElasticWhenever::CLI::SUCCESS_EXIT_CODE
+      end
+
       context "with an unchanged schedule" do
         before do
           expect(ElasticWhenever::Task::Rule).to receive(:fetch).and_return([rule])

--- a/spec/tasks/rule_spec.rb
+++ b/spec/tasks/rule_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe ElasticWhenever::Task::Rule do
     it "converts scheduled task syntax" do
       task = ElasticWhenever::Task.new("production", false, "bundle exec", "cron(0 0 * * ? *)")
       task.rake "hoge:run"
-      task.rake "command:foo"
 
       expect(ElasticWhenever::Task::Rule.convert(option, task.expression, task.commands.first)).to have_attributes(
                                                                      name: "test_6a6abf21a362cde702bd39f4679704598fad7ead",


### PR DESCRIPTION
The following changes have been made to allow our changes from the fork to be merged into the upstream (https://github.com/wata727/elastic_whenever/pull/57) - The changes are a result from the comments, and are largely about removing verbose logging.

I've made them as a separate PR instead of pushing directly to fac-main, as fac-main is our defacto main branch. Ideally, once  this is merged, we can get the PR (linked above) merged and not have to maintain the separate fork.